### PR TITLE
Link 컴포넌트 추가

### DIFF
--- a/src/Link/Link.stories.tsx
+++ b/src/Link/Link.stories.tsx
@@ -1,0 +1,30 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import Link from './Link';
+
+const meta: Meta<typeof Link> = {
+  title: 'Link',
+  component: Link,
+  args: {
+    children: '외부 링크로 이동합니다.',
+    href: '#',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Link>;
+
+export const Default: Story = {};
+
+export const Block: Story = {
+  render: ({ children }) => (
+    <>
+      <Link href="#" block isExternal>
+        {children}
+      </Link>
+      <Link href="#" block>
+        {children}
+      </Link>
+    </>
+  ),
+};

--- a/src/Link/Link.stories.tsx
+++ b/src/Link/Link.stories.tsx
@@ -5,6 +5,11 @@ import Link from './Link';
 const meta: Meta<typeof Link> = {
   title: 'Link',
   component: Link,
+  argTypes: {
+    href: {
+      table: { disable: true },
+    },
+  },
   args: {
     children: '외부 링크로 이동합니다.',
     href: '#',

--- a/src/Link/Link.tsx
+++ b/src/Link/Link.tsx
@@ -1,0 +1,35 @@
+import type { ComponentPropsWithoutRef } from 'react';
+import styled from 'styled-components';
+
+export interface LinkProps extends ComponentPropsWithoutRef<'a'> {
+  /**
+   * Link 컴포넌트의 링크 클릭 시 새로운 탭으로 열도록 선택할 수 있습니다.
+   */
+  isExternal?: boolean;
+  /**
+   * Link 컴포넌트의 디스플레이 속성이 block인지 선택할 수 있습니다.
+   */
+  block?: boolean;
+}
+
+const Link = ({ children, isExternal = false, block = false, css, ...props }: LinkProps) => {
+  return (
+    <LinkContainer
+      block={block}
+      target={isExternal ? '_blank' : undefined}
+      rel={isExternal ? 'noopener' : undefined}
+      css={css}
+      {...props}
+    >
+      {children}
+    </LinkContainer>
+  );
+};
+
+export default Link;
+
+type LinkStyleProps = Pick<LinkProps, 'block'>;
+
+const LinkContainer = styled.a<LinkStyleProps>`
+  display: ${({ block }) => (block ? 'block' : undefined)};
+`;

--- a/src/Link/index.ts
+++ b/src/Link/index.ts
@@ -1,0 +1,5 @@
+import Link from './Link';
+
+export type { LinkProps } from './Link';
+
+export default Link;


### PR DESCRIPTION
## Issue

- close #28 

## ✨ 구현한 기능

- 외부 링크를 연결하는 Link 컴포넌트 추가

## 📢 논의하고 싶은 내용

- react-router-dom의 Link, NavLink도 사용할 수 있도록 하고 싶었지만... 타입스크립트 문제로 일단 외부 링크만 사용 가능합니다.
  - https://chakra-ui.com/docs/components/link 문서와 같이 해보고 싶었지만 실패 🥲

## 🎸 기타

x
