### PR TITLE
feat: 체크박스 컴포넌트에 ref와 tabIndex 추가, dialog 태그에 z-index 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ const Parent = () => {
 | size?     | `xs`, `sm`, `md`, `lg`, `xl` <br /> (default: `md`) | Checkbox 컴포넌트의 체크박스 크기입니다. |
 | fontSize? | `xs`, `sm`, `md`, `lg`, `xl` <br /> (default: `md`) | Checkbox 컴포넌트의 폰트 크기입니다.     |
 | weight?   | `light`, `regular`, `bold` <br /> (default: `bold`) | Checkbox 컴포넌트의 폰트 가중치입니다.   |
+| tabIndex? | `-1`, `0`, `1` <br />                               | Checkbox 컴포넌트의 tabIndex입니다.      |
 
 ### Example
 

--- a/src/BottomSheet/BottomSheet.tsx
+++ b/src/BottomSheet/BottomSheet.tsx
@@ -34,6 +34,7 @@ type ModalWrapperStyleProps = Pick<BottomSheetProps, 'maxWidth'> & {
 
 const ModalDialog = styled.dialog`
   border: none;
+  z-index: 1000;
 `;
 
 const BackDrop = styled.div`

--- a/src/Checkbox/Checkbox.tsx
+++ b/src/Checkbox/Checkbox.tsx
@@ -1,4 +1,5 @@
-import type { ComponentPropsWithoutRef } from 'react';
+import type { ComponentPropsWithRef, ForwardedRef } from 'react';
+import { forwardRef } from 'react';
 import type { RuleSet } from 'styled-components';
 import styled, { css } from 'styled-components';
 
@@ -6,7 +7,7 @@ import type { FontWeightKeys } from '../styles/theme';
 import Text from '../Text';
 import type { Sizes } from '../types';
 
-type CheckboxBaseProps = Pick<ComponentPropsWithoutRef<'input'>, 'checked' | 'children' | 'onChange'>;
+type CheckboxBaseProps = Pick<ComponentPropsWithRef<'input'>, 'checked' | 'children' | 'onChange'>;
 
 export interface CheckboxProps extends CheckboxBaseProps {
   /**
@@ -21,11 +22,18 @@ export interface CheckboxProps extends CheckboxBaseProps {
    * Checkbox 컴포넌트의 라벨 폰트 가중치입니다.
    */
   weight?: FontWeightKeys;
+  /**
+   * Checkbox 컴포넌트의 tabIndex 값 입니다.
+   */
+  tabIndex?: -1 | 0 | 1;
 }
 
-const Checkbox = ({ children, size = 'md', fontSize = 'md', weight = 'regular', ...props }: CheckboxProps) => {
+const Checkbox = (
+  { children, size = 'md', fontSize = 'md', weight = 'regular', tabIndex, ...props }: CheckboxProps,
+  ref: ForwardedRef<HTMLLabelElement>
+) => {
   return (
-    <CheckboxContainer fontSize={fontSize} weight={weight}>
+    <CheckboxContainer ref={ref} fontSize={fontSize} weight={weight} tabIndex={tabIndex}>
       <CheckboxWrapper type="checkbox" size={size} {...props} />
       <CheckText as="span" size={size} aria-hidden="true" />
       <LabelText as="span">{children}</LabelText>
@@ -33,7 +41,7 @@ const Checkbox = ({ children, size = 'md', fontSize = 'md', weight = 'regular', 
   );
 };
 
-export default Checkbox;
+export default forwardRef(Checkbox);
 
 type CheckboxStyleProps = Pick<CheckboxProps, 'size' | 'fontSize' | 'weight'>;
 


### PR DESCRIPTION
## Issue

- close #57 

## ✨ 구현한 기능

- 체크박스 컴포넌트에 ref와 tabIndex를 추가했습니다.
- dialog 태그에 z-index를 추가했습니다.
- 문서를 업데이트 했습니다.

## 📢 논의하고 싶은 내용

- z-index를 0, -1, 1로 제한한 이유 (이 외의 값은 안 쓰는 것이 맞다고 생각해서!)
<img width="774" alt="스크린샷 2023-08-03 오후 8 02 23" src="https://github.com/fun-eat/design-system/assets/55427367/3f0a112a-3b28-4481-9949-388118bf20a2">
(출처 MDN)




## 🎸 기타

x
