### PR TITLE
Divider 수정과 Bottom sheet 속도 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,15 +132,16 @@ const Parent = () => {
 
 ### Props
 
-| props    | value                                                      | description                                                 |
-| -------- | ---------------------------------------------------------- | ----------------------------------------------------------- |
-| variant? | `default`, `strong`, `disabled` <br />(default: `default`) | Divider 컴포넌트의 종류입니다. 강조의 정도 차이가 있습니다. |
-| width?   | string <br />(default: 100%)                               | Divider 컴포넌트의 길이입니다.                              |
+| props         | value                                                 | description                                                 |
+| ------------- | ----------------------------------------------------- | ----------------------------------------------------------- |
+| variant?      | default , strong , disabled <br /> (default: default) | Divider 컴포넌트의 종류입니다. 강조의 정도 차이가 있습니다. |
+| customWidth?  | string <br /> (default: 100%)                         | Divider 컴포넌트의 길이입니다.                              |
+| customHeight? | string <br /> (default: 1px)                          | Divider 컴포넌트의 두께입니다.                              |
 
 ### Example
 
 ```jsx
-<Divider variant="strong" width="50%" />
+<Divider variant="strong" customWidth="50%" customHeight='4px'/>
 <Divider />
 ```
 

--- a/src/BottomSheet/BottomSheet.stories.tsx
+++ b/src/BottomSheet/BottomSheet.stories.tsx
@@ -56,3 +56,91 @@ export const WithMaxWidth: Story = {
     );
   },
 };
+
+export const MaxHeight: Story = {
+  render: () => {
+    const { ref, isClosing, handleOpenBottomSheet, handleCloseBottomSheet } = useBottomSheet();
+
+    return (
+      <>
+        <button type="button" style={{ padding: '10px', border: '1px solid gray' }} onClick={handleOpenBottomSheet}>
+          바텀시트 열기
+        </button>
+        <BottomSheet isClosing={isClosing} close={handleCloseBottomSheet} ref={ref}>
+          <div style={{ padding: '20px' }}>
+            Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical
+            Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at
+            Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem
+            Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable
+            source. Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of "de Finibus Bonorum et Malorum" (The Extremes
+            of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular
+            during the Renaissance. The first line of Lorem Ipsum, "Lorem ipsum dolor sit amet..", comes from a line in
+            section 1.10.32. The standard chunk of Lorem Ipsum used since the 1500s is reproduced below for those
+            interested. Sections 1.10.32 and 1.10.33 from "de Finibus Bonorum et Malorum" by Cicero are also reproduced
+            in their exact original form, accompanied by English versions from the 1914 translation by H. Rackham.
+            Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical
+            Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at
+            Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem
+            Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable
+            source. Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of "de Finibus Bonorum et Malorum" (The Extremes
+            of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular
+            during the Renaissance. The first line of Lorem Ipsum, "Lorem ipsum dolor sit amet..", comes from a line in
+            section 1.10.32. The standard chunk of Lorem Ipsum used since the 1500s is reproduced below for those
+            interested. Sections 1.10.32 and 1.10.33 from "de Finibus Bonorum et Malorum" by Cicero are also reproduced
+            in their exact original form, accompanied by English versions from the 1914 translation by H. Rackham.
+            Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical
+            Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at
+            Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem
+            Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable
+            source. Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of "de Finibus Bonorum et Malorum" (The Extremes
+            of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular
+            during the Renaissance. The first line of Lorem Ipsum, "Lorem ipsum dolor sit amet..", comes from a line in
+            section 1.10.32. The standard chunk of Lorem Ipsum used since the 1500s is reproduced below for those
+            interested. Sections 1.10.32 and 1.10.33 from "de Finibus Bonorum et Malorum" by Cicero are also reproduced
+            in their exact original form, accompanied by English versions from the 1914 translation by H. Rackham.
+            Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical
+            Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at
+            Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem
+            Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable
+            source. Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of "de Finibus Bonorum et Malorum" (The Extremes
+            of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular
+            during the Renaissance. The first line of Lorem Ipsum, "Lorem ipsum dolor sit amet..", comes from a line in
+            section 1.10.32. The standard chunk of Lorem Ipsum used since the 1500s is reproduced below for those
+            interested. Sections 1.10.32 and 1.10.33 from "de Finibus Bonorum et Malorum" by Cicero are also reproduced
+            in their exact original form, accompanied by English versions from the 1914 translation by H. Rackham.
+            Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical
+            Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at
+            Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem
+            Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable
+            source. Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of "de Finibus Bonorum et Malorum" (The Extremes
+            of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular
+            during the Renaissance. The first line of Lorem Ipsum, "Lorem ipsum dolor sit amet..", comes from a line in
+            section 1.10.32. The standard chunk of Lorem Ipsum used since the 1500s is reproduced below for those
+            interested. Sections 1.10.32 and 1.10.33 from "de Finibus Bonorum et Malorum" by Cicero are also reproduced
+            in their exact original form, accompanied by English versions from the 1914 translation by H. Rackham.
+            Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical
+            Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at
+            Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem
+            Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable
+            source. Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of "de Finibus Bonorum et Malorum" (The Extremes
+            of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular
+            during the Renaissance. The first line of Lorem Ipsum, "Lorem ipsum dolor sit amet..", comes from a line in
+            section 1.10.32. The standard chunk of Lorem Ipsum used since the 1500s is reproduced below for those
+            interested. Sections 1.10.32 and 1.10.33 from "de Finibus Bonorum et Malorum" by Cicero are also reproduced
+            in their exact original form, accompanied by English versions from the 1914 translation by H. Rackham.
+            Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical
+            Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at
+            Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem
+            Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable
+            source. Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of "de Finibus Bonorum et Malorum" (The Extremes
+            of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular
+            during the Renaissance. The first line of Lorem Ipsum, "Lorem ipsum dolor sit amet..", comes from a line in
+            section 1.10.32. The standard chunk of Lorem Ipsum used since the 1500s is reproduced below for those
+            interested. Sections 1.10.32 and 1.10.33 from "de Finibus Bonorum et Malorum" by Cicero are also reproduced
+            in their exact original form, accompanied by English versions from the 1914 translation by H. Rackham.
+          </div>
+        </BottomSheet>
+      </>
+    );
+  },
+};

--- a/src/BottomSheet/BottomSheet.tsx
+++ b/src/BottomSheet/BottomSheet.tsx
@@ -59,7 +59,7 @@ const ModalWrapper = styled.div<ModalWrapperStyleProps>`
   border-radius: 12px 12px 0px 0px;
   background: ${({ theme }) => theme.colors.white};
   overflow-y: auto;
-  animation: ${({ isClosing }) => (isClosing ? slideDown : slideUp)} 0.3s;
+  animation: ${({ isClosing }) => (isClosing ? slideDown : slideUp)} 0.5s;
 
   &::-webkit-scrollbar {
     display: none;

--- a/src/BottomSheet/useBottomSheet.ts
+++ b/src/BottomSheet/useBottomSheet.ts
@@ -10,8 +10,9 @@ export const useBottomSheet = () => {
     const timer = setTimeout(() => {
       setIsClosing(false);
       ref.current?.close();
-      clearTimeout(timer);
-    }, 100);
+    }, 370);
+
+    return () => clearTimeout(timer);
   }, []);
 
   const handleOpenBottomSheet = () => {

--- a/src/Divider/Divider.stories.tsx
+++ b/src/Divider/Divider.stories.tsx
@@ -32,3 +32,9 @@ export const Disabled: Story = {
     variant: 'disabled',
   },
 };
+
+export const HightLight: Story = {
+  args: {
+    customHeight: '4px',
+  },
+};

--- a/src/Divider/Divider.tsx
+++ b/src/Divider/Divider.tsx
@@ -9,16 +9,22 @@ export interface DividerProps extends ComponentPropsWithoutRef<'hr'> {
   /**
    * Divider 컴포넌트의 길이입니다.
    */
-  width?: string;
+  customWidth?: string;
+  /**
+   * Divider 컴포넌트의 두께입니다.
+   */
+  customHeight?: string;
 }
 
-const Divider = ({ variant = 'default', width = '100%', css, ...props }: DividerProps) => {
-  return <DividerContainer variant={variant} width={width} css={css} {...props} />;
+const Divider = ({ variant = 'default', customWidth = '100%', customHeight = '1px', css, ...props }: DividerProps) => {
+  return (
+    <DividerContainer variant={variant} customWidth={customWidth} customHeight={customHeight} css={css} {...props} />
+  );
 };
 
 export default Divider;
 
-type DividerStyleProps = Pick<DividerProps, 'variant' | 'width'>;
+type DividerStyleProps = Pick<DividerProps, 'variant' | 'customWidth' | 'customHeight'>;
 
 const dividerStyles = {
   default: css`
@@ -35,6 +41,7 @@ const dividerStyles = {
 const DividerContainer = styled.hr<DividerStyleProps>`
   ${({ variant }) => dividerStyles[variant ?? 'default']};
   height: 1px;
-  width: ${({ width }) => width};
+  width: ${({ customWidth }) => customWidth};
+  height: ${({ customHeight }) => customHeight};
   border: 0;
 `;

--- a/src/styles/animations.ts
+++ b/src/styles/animations.ts
@@ -2,18 +2,18 @@ import { keyframes } from 'styled-components';
 
 export const slideUp = keyframes`
   0% {
-    bottom: -300px;
+    bottom: -100%;
   }
   100% {
-    bottom: 0;
+    bottom: 0%;
   }
 `;
 
 export const slideDown = keyframes`
   0% {
-    bottom: 0;
+    bottom: 0%;
   }
   100% {
-    bottom:-300px
+    bottom:-100%;
   }
 `;


### PR DESCRIPTION
## Issue

- close #54 
- close #56 

## ✨ 구현한 기능

divider에 높이를 추가했습니다. 
그 과정에서 width -> customWidth로 이름을 수정했습니다.

Bottom sheet 속도도 수정하였는데요.
Bottom sheet가 내려가기 전에 뒤 백드롭이 먼저 꺼져서 내려가는 애니메이션이 이상했던 것이었읍니다.
근데 한줄만 있는 버전이랑 꽉 찬 버전이랑 내려가는 속도가 당연히 다르기 때문에 그나마 중간 지점을 맞췄어요.
그래서 한줄 버전은 생각보다 백드롭이 좀 늦게 꺼지고 꽉 찬 버전은 약간 빨리 꺼지는 느낌이 든다면 그게 맞습니다 ㅠ


## 📢 논의하고 싶은 내용

색상의 경우 아직 추가하지 않았는데요.
저희 예전에 색상 투표 했을 때 남은 색상 하나를 들고와 약간 손질을 했습니다.

<img width="388" alt="스크린샷 2023-08-05 오후 9 19 35" src="https://github.com/fun-eat/design-system/assets/80464961/cb573964-0a1f-4a00-86a6-86920f78c50e">

이런 느낌일텐데 어떤가요? 많은 의견주세요.
그리고 이 색상 이름...뭐라고 해야할 지 모르겠어요. 이것도 의견 주세요 🫠

## 🎸 기타

x
