### PR TITLE
refactor: Dialog 레이어 쌓임 문제 해결

### DIFF
--- a/src/BottomSheet/BottomSheet.stories.tsx
+++ b/src/BottomSheet/BottomSheet.stories.tsx
@@ -1,8 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { useBottomSheet } from './useBottomSheet';
-// 오류로 인해 임시 설정
-import React from 'react';
+
 import BottomSheet from './BottomSheet';
 import { useToastActionContext } from '../Toast/context/useToastActionContext';
 

--- a/src/BottomSheet/BottomSheet.stories.tsx
+++ b/src/BottomSheet/BottomSheet.stories.tsx
@@ -1,7 +1,10 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
-import BottomSheet from './BottomSheet';
 import { useBottomSheet } from './useBottomSheet';
+// 오류로 인해 임시 설정
+import React from 'react';
+import BottomSheet from './BottomSheet';
+import { useToastActionContext } from '../Toast/context/useToastActionContext';
 
 const meta: Meta<typeof BottomSheet> = {
   title: 'BottomSheet',
@@ -25,14 +28,14 @@ type Story = StoryObj<typeof BottomSheet>;
 
 export const Default: Story = {
   render: () => {
-    const { isOpen, isClosing, handleOpenBottomSheet, handleCloseBottomSheet } = useBottomSheet();
+    const { ref, isClosing, handleOpenBottomSheet, handleCloseBottomSheet } = useBottomSheet();
 
     return (
       <>
         <button type="button" style={{ padding: '10px', border: '1px solid gray' }} onClick={handleOpenBottomSheet}>
           바텀시트 열기
         </button>
-        <BottomSheet isOpen={isOpen} isClosing={isClosing} close={handleCloseBottomSheet}>
+        <BottomSheet isClosing={isClosing} close={handleCloseBottomSheet} ref={ref}>
           <div style={{ padding: '20px' }}>바텀시트 컴포넌트</div>
         </BottomSheet>
       </>
@@ -40,16 +43,16 @@ export const Default: Story = {
   },
 };
 
-export const WithMaxWidth: Story = {
+export const MaxWidth: Story = {
   render: () => {
-    const { isOpen, isClosing, handleOpenBottomSheet, handleCloseBottomSheet } = useBottomSheet();
+    const { ref, isClosing, handleOpenBottomSheet, handleCloseBottomSheet } = useBottomSheet();
 
     return (
       <>
         <button type="button" style={{ padding: '10px', border: '1px solid gray' }} onClick={handleOpenBottomSheet}>
           바텀시트 열기
         </button>
-        <BottomSheet isOpen={isOpen} isClosing={isClosing} maxWidth="300px" close={handleCloseBottomSheet}>
+        <BottomSheet isClosing={isClosing} maxWidth="300px" close={handleCloseBottomSheet} ref={ref}>
           <div style={{ padding: '20px' }}>바텀시트 컴포넌트</div>
         </BottomSheet>
       </>
@@ -59,14 +62,14 @@ export const WithMaxWidth: Story = {
 
 export const MaxHeight: Story = {
   render: () => {
-    const { isOpen, isClosing, handleOpenBottomSheet, handleCloseBottomSheet } = useBottomSheet();
+    const { ref, isClosing, handleOpenBottomSheet, handleCloseBottomSheet } = useBottomSheet();
 
     return (
       <>
         <button type="button" style={{ padding: '10px', border: '1px solid gray' }} onClick={handleOpenBottomSheet}>
           바텀시트 열기
         </button>
-        <BottomSheet isOpen={isOpen} isClosing={isClosing} close={handleCloseBottomSheet}>
+        <BottomSheet isClosing={isClosing} close={handleCloseBottomSheet} ref={ref}>
           <div style={{ padding: '20px' }}>
             Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical
             Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at
@@ -138,6 +141,26 @@ export const MaxHeight: Story = {
             section 1.10.32. The standard chunk of Lorem Ipsum used since the 1500s is reproduced below for those
             interested. Sections 1.10.32 and 1.10.33 from "de Finibus Bonorum et Malorum" by Cicero are also reproduced
             in their exact original form, accompanied by English versions from the 1914 translation by H. Rackham.
+          </div>
+        </BottomSheet>
+      </>
+    );
+  },
+};
+
+export const WithToast: Story = {
+  render: () => {
+    const { ref, isClosing, handleOpenBottomSheet, handleCloseBottomSheet } = useBottomSheet();
+    const { toast } = useToastActionContext();
+
+    return (
+      <>
+        <button type="button" style={{ padding: '10px', border: '1px solid gray' }} onClick={handleOpenBottomSheet}>
+          바텀시트 열기
+        </button>
+        <BottomSheet hasToast isClosing={isClosing} close={handleCloseBottomSheet} ref={ref}>
+          <div style={{ padding: '20px' }}>
+            <button onClick={() => toast.success('토스트 테스트 중')}>토스트 버튼</button>
           </div>
         </BottomSheet>
       </>

--- a/src/BottomSheet/BottomSheet.tsx
+++ b/src/BottomSheet/BottomSheet.tsx
@@ -8,6 +8,7 @@ import { slideDown, slideUp } from '../styles/animations';
 export interface BottomSheetProps extends ComponentPropsWithRef<'dialog'> {
   isClosing: boolean;
   maxWidth?: string;
+  maxHeight?: string;
   hasToast?: boolean;
   close: () => void;
 }
@@ -16,7 +17,7 @@ const containerElement =
   window.location.port === '6006' ? document.body : (document.getElementById('dialog-container') as HTMLElement);
 
 const BottomSheet = (
-  { maxWidth, isClosing, close, hasToast, children, ...props }: BottomSheetProps,
+  { maxWidth, maxHeight, isClosing, close, hasToast, children, ...props }: BottomSheetProps,
   ref: ForwardedRef<HTMLDialogElement>
 ) => {
   return createPortal(
@@ -33,7 +34,7 @@ const BottomSheet = (
 
 export default forwardRef(BottomSheet);
 
-type ModalWrapperStyleProps = Pick<BottomSheetProps, 'maxWidth'> & {
+type ModalWrapperStyleProps = Pick<BottomSheetProps, 'maxWidth' | 'maxHeight'> & {
   isClosing: boolean;
 };
 
@@ -60,7 +61,7 @@ const ModalWrapper = styled.div<ModalWrapperStyleProps>`
   left: 0;
   width: 100%;
   max-width: ${({ maxWidth }) => maxWidth};
-  max-height: 436px;
+  max-height: ${({ maxHeight }) => maxHeight}
   border-radius: 12px 12px 0px 0px;
   background: ${({ theme }) => theme.colors.white};
   overflow-y: auto;

--- a/src/BottomSheet/BottomSheet.tsx
+++ b/src/BottomSheet/BottomSheet.tsx
@@ -5,10 +5,10 @@ import styled from 'styled-components';
 
 import { slideDown, slideUp } from '../styles/animations';
 
-export interface BottomSheetProps extends ComponentPropsWithRef<'div'> {
-  maxWidth?: string;
-  isOpen: boolean;
+export interface BottomSheetProps extends ComponentPropsWithRef<'dialog'> {
   isClosing: boolean;
+  maxWidth?: string;
+  hasToast?: boolean;
   close: () => void;
 }
 
@@ -16,20 +16,17 @@ const containerElement =
   window.location.port === '6006' ? document.body : (document.getElementById('dialog-container') as HTMLElement);
 
 const BottomSheet = (
-  { maxWidth, isOpen, isClosing, close, children, ...props }: BottomSheetProps,
-  ref: ForwardedRef<HTMLDivElement>
+  { maxWidth, isClosing, close, hasToast, children, ...props }: BottomSheetProps,
+  ref: ForwardedRef<HTMLDialogElement>
 ) => {
   return createPortal(
-    <>
-      {isOpen && (
-        <ModalDialog role="dialog" ref={ref} {...props}>
-          <BackDrop onClick={close} />
-          <ModalWrapper maxWidth={maxWidth} isClosing={isClosing}>
-            {children}
-          </ModalWrapper>
-        </ModalDialog>
-      )}
-    </>,
+    <ModalDialog ref={ref} {...props}>
+      <BackDrop onClick={close} />
+      <ModalWrapper maxWidth={maxWidth} isClosing={isClosing}>
+        {children}
+      </ModalWrapper>
+      {hasToast && <div id="toast-in-dialog-container" aria-hidden />}
+    </ModalDialog>,
     containerElement
   );
 };
@@ -40,10 +37,9 @@ type ModalWrapperStyleProps = Pick<BottomSheetProps, 'maxWidth'> & {
   isClosing: boolean;
 };
 
-const ModalDialog = styled.div`
-  position: relative;
+const ModalDialog = styled.dialog`
   border: none;
-  z-index: 9999;
+  z-index: 1000;
 `;
 
 const BackDrop = styled.div`

--- a/src/BottomSheet/BottomSheet.tsx
+++ b/src/BottomSheet/BottomSheet.tsx
@@ -60,7 +60,7 @@ const ModalWrapper = styled.div<ModalWrapperStyleProps>`
   left: 0;
   width: 100%;
   max-width: ${({ maxWidth }) => maxWidth};
-  max-height: 100%;
+  max-height: 436px;
   border-radius: 12px 12px 0px 0px;
   background: ${({ theme }) => theme.colors.white};
   overflow-y: auto;

--- a/src/BottomSheet/useBottomSheet.ts
+++ b/src/BottomSheet/useBottomSheet.ts
@@ -1,42 +1,32 @@
-import type { KeyboardEventHandler } from 'react';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
+import { useToastActionContext } from '../Toast';
 
 export const useBottomSheet = () => {
-  const [isOpen, setIsOpen] = useState(false);
   const [isClosing, setIsClosing] = useState(false);
-  const ref = useRef<HTMLDivElement>(null);
+  const ref = useRef<HTMLDialogElement>(null);
+
+  const { setToastId } = useToastActionContext();
 
   const closeAnimated = useCallback(() => {
     setIsClosing(true);
 
     const timer = setTimeout(() => {
       setIsClosing(false);
-      setIsOpen(false);
+      ref.current?.close();
     }, 370);
 
     return () => clearTimeout(timer);
   }, []);
 
   const handleOpenBottomSheet = () => {
-    setIsOpen(true);
+    setToastId('toast-in-dialog-container');
+    ref.current?.showModal();
   };
 
   const handleCloseBottomSheet = () => {
+    setToastId('toast-container');
     closeAnimated();
   };
 
-  const handleKeydown = (e: KeyboardEvent) => {
-    if (e.keyCode === 27) {
-      e.preventDefault();
-      handleCloseBottomSheet();
-    }
-  };
-
-  useEffect(() => {
-    document.addEventListener('keydown', handleKeydown);
-
-    return () => document.removeEventListener('keydown', handleKeydown);
-  }, [handleKeydown]);
-
-  return { ref, isOpen, isClosing, handleOpenBottomSheet, handleCloseBottomSheet };
+  return { ref, isClosing, handleOpenBottomSheet, handleCloseBottomSheet };
 };

--- a/src/Toast/context/ToastContext.tsx
+++ b/src/Toast/context/ToastContext.tsx
@@ -4,6 +4,7 @@ import { createPortal } from 'react-dom';
 import styled from 'styled-components';
 
 import Toast from '..';
+import { ToastId } from '../../types';
 
 export interface ToastState {
   id: number;
@@ -21,6 +22,7 @@ export interface ToastAction {
     error: (message: string) => void;
   };
   deleteToast: (id: number) => void;
+  setToastId: (id: ToastId) => void;
 }
 
 export const ToastValueContext = createContext<ToastValue | null>(null);
@@ -28,6 +30,7 @@ export const ToastActionContext = createContext<ToastAction | null>(null);
 
 export const ToastProvider = ({ children }: PropsWithChildren) => {
   const [toasts, setToasts] = useState<ToastState[]>([]);
+  const [toastElementId, setToastElementId] = useState<ToastId>('toast-container');
 
   const showToast = (id: number, message: string, isError?: boolean) => {
     setToasts([...toasts, { id, message, isError }]);
@@ -35,6 +38,10 @@ export const ToastProvider = ({ children }: PropsWithChildren) => {
 
   const deleteToast = (id: number) => {
     setToasts((prevToasts) => prevToasts.filter((toast) => toast.id !== id));
+  };
+
+  const setToastId = (id: ToastId) => {
+    setToastElementId(id);
   };
 
   const toast = {
@@ -49,6 +56,7 @@ export const ToastProvider = ({ children }: PropsWithChildren) => {
   const toastAction = {
     toast,
     deleteToast,
+    setToastId,
   };
 
   return (
@@ -61,7 +69,7 @@ export const ToastProvider = ({ children }: PropsWithChildren) => {
               <Toast key={id} id={id} message={message} isError={isError} />
             ))}
           </ToastContainer>,
-          document.getElementById('toast-container') as HTMLElement
+          document.getElementById(toastElementId) as HTMLElement
         )}
       </ToastValueContext.Provider>
     </ToastActionContext.Provider>

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,3 +6,5 @@ export type OverridableComponentPropsWithRef<T extends ElementType, P = unknown>
   ComponentPropsWithRef<T> & { as?: T };
 export type OverridableComponentPropsWithoutRef<T extends ElementType, P = unknown> = P &
   ComponentPropsWithoutRef<T> & { as?: T };
+
+export type ToastId = 'toast-container' | 'toast-in-dialog-container';


### PR DESCRIPTION
## Issue

- close #95

## ✨ 구현한 기능

여러분 드디어 고쳤습니다...!
toast id를 따로 상태로 둬서 일반 상황에서는 'toast-container'라는 div에 붙고
dialog 내부에서는 'toast-in-dialog-container' div에 붙도록 하였습니다.


이랬는데
<img width="554" alt="스크린샷 2024-03-25 오후 6 17 46" src="https://github.com/fun-eat/design-system/assets/80464961/d7b1f7ab-cfe8-4c64-8381-7cf8d1ff2682">

요래 됐슴다
<img width="575" alt="스크린샷 2024-03-25 오후 9 40 44" src="https://github.com/fun-eat/design-system/assets/80464961/c6d9d181-18d4-4217-ac94-dbb35c702446">

이제 BottomSheet 사용처에서 hasToast라는 props를 주면 상위에 뜹니다!

```tsx
<BottomSheet hasToast ...>
```

## 📢 논의하고 싶은 내용

styled를 module css로 바꾸려고 했는데 다른 곳에서는 문제가 없는데
스토리북에서는 계속 에러가 뜨더라구요.
이게 찾아봤을 때 storybook main.ts webpack 설정 때문에 그렇다는데 있는 코드들도 main.js 밖에 없고 제대로 되는 것도 없더라구요.
어차피 우리 rollupjs로 바꿀거여서 그때 다시 적용해야하니까 스타일은 따로 안 바꿨습니다!

## 🎸 기타

갑자기 디자인시스템 스토리북에 왜 React를 import를 안해주면 에러가 나죠? 저만 그런가요??
